### PR TITLE
Include ways and relations in query

### DIFF
--- a/load-overpass.sh
+++ b/load-overpass.sh
@@ -21,6 +21,10 @@ CURL_BIN=curl
 JQ_BIN=jq
 GZIP_BIN=gzip
 
+# Overpass query
+
+QUERY="[out:json][timeout:$TIMEOUT_SECONDS]; ( node[amenity=charging_station]; area[amenity=charging_station]; relation[amenity=charging_station]; ); out meta qt;"
+
 # Helper functions
 
 function log() { echo -e "\e[32m$1\e[0m"; }
@@ -30,7 +34,7 @@ function loge() { echo -e "\e[31m$1\e[0m"; }
 
 log "1: Downloading data through Overpass API (this may take up to $TIMEOUT_SECONDS seconds...)"
 $CURL_BIN \
-    --data "[out:json][timeout:$TIMEOUT_SECONDS]; node[amenity=charging_station]; out meta qt;" \
+    --data "$QUERY" \
     --header 'content-type: text/plain' \
     -o $OUTFILE_RAW \
     $OVERPASS_INTERPRETER
@@ -49,7 +53,7 @@ $JQ_BIN "{
     timestamp: now,
     count: $found_elements,
     elements: [
-        .elements[] | {id,lat,lon,timestamp,version,user,tags}
+        .elements[] | {id,lat,lon,timestamp,type,version,user,tags}
     ]
 }"  $OUTFILE_RAW | $GZIP_BIN -9 > $OUTFILE_COMPRESSED
 size_compressed=$(du -h $OUTFILE_COMPRESSED | cut -f1)


### PR DESCRIPTION
Add ways (areas) and relations to overpass query. See https://github.com/ev-map/EVMap/issues/391 for context.

In Switzerland, this increases the match count from 4352 stations to 4529 stations.